### PR TITLE
Update .NET agent 9.5.0 release notes to add warning for Alpine Linux users

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9500.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9500.mdx
@@ -4,6 +4,7 @@ releaseDate: '2022-02-01'
 version: 9.5.0.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
 ---
+## **\*\*WARNING\*\*** Do not install this version if you are using the agent on Alpine Linux; it will crash your applications.  See [this issue](https://github.com/newrelic/newrelic-dotnet-agent/issues/918) for more details.
 
 ### New Features
 * Internal improvements to runtime detection logic in the profiler component of the agent. ([#891](https://github.com/newrelic/newrelic-dotnet-agent/pull/891))


### PR DESCRIPTION
Add a warning for Alpine Linux customers not to install the 9.5.0 version because of an app crash bug.